### PR TITLE
[QTRX-12] - Initialize and setup the monorepo architecture

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,5 @@
     "tslib": "^2.3.0",
     "typescript": "~5.7.2"
   },
-  "packageManager": "pnpm@10.8.0+sha512.0e82714d1b5b43c74610193cb20734897c1d00de89d0e18420aebc5977fa13d780a9cb05734624e81ebd81cc876cd464794850641c48b9544326b5622ca29971"
+  "packageManager": "pnpm@10.8.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages: 
   - "packages/*"
+  - "apps/*"
+  - "svgs/*"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,7 @@
     "noUnusedLocals": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2022",
+    "target": "ESNext",
     "customConditions": ["development"]
   }
 }


### PR DESCRIPTION
As a developer, I want to set up a monorepo using Nx so that I can manage all design system packages (icons, components, tokens, utilities, etc.) from a single workspace.

**Acceptance Criteria:**
- [x] Create qeetrix repository in Github
- [x] An Nx monorepo is initialized.
- [x] Folder structure includes `/apps`, `/packages`, & `/svgs`.
- [ ] Monorepo builds and serves at least one demo package.


[Story Link](https://qeetgroup.atlassian.net/browse/QTRX-12)
